### PR TITLE
Workaround to the LTO build issue of UnicornSampleArm64

### DIFF
--- a/efi/UnicornArm64Lib.inf
+++ b/efi/UnicornArm64Lib.inf
@@ -80,7 +80,7 @@
 GCC:*_*_*_CC_FLAGS = -nostdinc -I$(MODULE_DIR)/.. -I$(MODULE_DIR)/../include -I$(MODULE_DIR)/../qemu -I$(MODULE_DIR)/../qemu/include -I$(MODULE_DIR)/../qemu/tcg -I$(MODULE_DIR)/../qemu/target/arm -I$(MODULE_DIR)/../glib_compat -include $(UNICORN_EMU_ARCH).h -DCONFIG_TARGET_HEADER=\"config-target-$(UNICORN_EMU_ARCH).h\" -DUNICORN_FOR_EFI -DUNICORN_HAS_ARM64 -DNEED_CPU_H -DUNICORN_FOR_EFI_INTERNAL
 
 [BuildOptions.AARCH64]
-GCC:*_*_*_CC_FLAGS = -I$(MODULE_DIR)/../qemu/tcg/aarch64
+GCC:*_*_*_CC_FLAGS = -I$(MODULE_DIR)/../qemu/tcg/aarch64 -fno-lto
 
 [BuildOptions.RISCV64]
 GCC:*_*_*_CC_FLAGS = -I$(MODULE_DIR)/../qemu/tcg/riscv


### PR DESCRIPTION
The issue is due to the -flto option, the build takes forever and then bombs out complaining about missing __ashrti3 if with this option. Furthermore, the issue is caused by the below two files qemu/accel/tcg/translate-all.c, the macro TB_FOR_EACH_TAGGED causes a lot of link time if with -flto GCC flag
qemu/exec.c, the GCC LTO is not working well with Int128 shift operation (complaining about missing __ashrti3.)
The workaround here is to disable lto GCC flag in UnicornArm64Lib.inf, so it won't need to change the EDK2 Conf/tools_def.txt to avoid LTO