### PR TITLE
efi: model rdrand which always fails

### DIFF
--- a/qemu/target/i386/unicorn.c
+++ b/qemu/target/i386/unicorn.c
@@ -74,6 +74,11 @@ void x86_reg_reset(struct uc_struct *uc)
     env->features[FEAT_1_ECX] = CPUID_EXT_SSSE3 | CPUID_EXT_SSE41 |
                                 CPUID_EXT_SSE42 | CPUID_EXT_AES |
                                 CPUID_EXT_CX16;
+
+#ifdef UNICORN_FOR_EFI
+    env->features[FEAT_1_ECX] |= CPUID_EXT_RDRAND;
+#endif /* UNICORN_FOR_EFI */
+
     env->features[FEAT_8000_0001_EDX] = CPUID_EXT2_3DNOW | CPUID_EXT2_RDTSCP;
     env->features[FEAT_8000_0001_ECX] = CPUID_EXT3_LAHF_LM | CPUID_EXT3_ABM |
                                         CPUID_EXT3_SKINIT | CPUID_EXT3_CR8LEG;


### PR DESCRIPTION
In a UEFI environment, rdrand is modeled but always fails. The use case is MultiArchUefiPkg. Some drivers use rdrand, but subsequently scribble to bottom 64k of RAM on success.

Yes, it's a hack. Hopefully will never need to deal with code that expects rdrand to succeed.  If that ever happens, MUA will need to negotiate these little warts based on driver fingerprinting. That'll be exciting...

Good code should be using proper RNG protocols anyway...

See https://github.com/intel/MultiArchUefiPkg/issues/48