### PR TITLE
glib_compat/glib_compact: Clear the buffer in g_hash_table_resize

### DIFF
--- a/glib_compat/glib_compat.c
+++ b/glib_compat/glib_compat.c
@@ -716,6 +716,7 @@ static void g_hash_table_resize (GHashTable *hash_table)
     g_hash_table_set_shift_from_size (hash_table, hash_table->nnodes * 2);
 
     new_nodes = g_new0 (GHashNode, hash_table->size);
+    memset(new_nodes, 0, hash_table->size * sizeof(GHashNode));
 
     for (i = 0; i < old_size; i++)
     {


### PR DESCRIPTION
There has a hidden danger in g_hash_table_resize function:

The g_hash_table_resize, it seems to resize the has table, and write the old value to the new hash table. It seems look for the empty items in the new_nodes, and if the new_nodes is not be cleared, it maybe naver found the empty items. So I added a line under the g_new0 function, and I think clearing new_nodes every time may improve the performance.

Added a memset to clear the new_nodes to fix this problem.